### PR TITLE
New List for Language Technology Standards

### DIFF
--- a/Standards used in Language Technology.md
+++ b/Standards used in Language Technology.md
@@ -1,0 +1,40 @@
+#Standards used in Language Technology and Lingusitics
+
+##Language Identification
+* ISO 639-1
+* ISO 639-2
+* ISO 639-3
+* ISO 639-4
+* ISO 639-5
+* ISO 639-6
+
+* Language tags as defined by the Internet Engineering Task Force (IETF)
+* BCP 47: [Best Current Practice 47](https://tools.ietf.org/html/bcp47), which includes RFC 5646
+* RFC 5646, which superseded RFC 4646, which superseded [RFC 3066](https://www.ietf.org/rfc/rfc3066.txt). (Therefore all standards which depend on any of these 3 IETF standards now use ISO 639-3.)
+
+
+Text Encoding Initiative (TEI):[29] via IETF's BCP 47.
+Lexical Markup Framework: ISO specification for representation of machine-readable dictionaries.
+Unicode's Common locale data repository: Uses several hundred codes from ISO 639-3 not included in ISO 639-2.
+
+##Script Identification
+
+##Metadata
+* OLAC 1.1 [OLAC: the Open Languages Archive Community](http://www.language-archives.org/REC/language.html)
+* Dublin Core Metadata Initiative: DCMI Metadata Term for language, via IETF's RFC 4646 (now superseded by RFC 5646)
+* HTML5:[27] via IETF's BCP 47.
+* MARC library codes.
+* MODS (Metadata Object Description Schema) [library codes](http://www.loc.gov/standards/mods/v3/mods-userguide-elements.html): Incorporates IETF's RFC 3066 (now superseded by RFC 5646).
+
+
+* Other standards that rely on ISO 639-3:
+** [[IETF language tag|Language tags]] as defined by the [[IETF|Internet Engineering Task Force (IETF)]], as documented in:
+*** RFC 5646, which superseded RFC 4646, which superseded [https://www.ietf.org/rfc/rfc3066.txt RFC 3066]. (Therefore all standards which depend on any of these 3 IETF standards now use ISO 639-3.)
+** [[Dublin Core|Dublin Core Metadata Initiative]]: DCMI Metadata Term<ref>http://purl.org/dc/elements/1.1/language</ref> for language, via IETF's RFC 4646 (now superseded by RFC 5646).
+** HTML5:<ref>http://www.w3.org/TR/html5/dom.html#the-lang-and-xml:lang-attributes</ref> via IETF's BCP 47.
+** [[MARC standards|MARC]] library codes.
+** [[Metadata Object Description Schema|MODS]] library codes:<ref>http://www.loc.gov/standards/mods/v3/mods-userguide-elements.html</ref> Incorporates IETF's [https://www.ietf.org/rfc/rfc3066.txt RFC 3066] (now superseded by RFC 5646).
+** Text Encoding Initiative (TEI):<ref>http://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-language.html</ref> via IETF's BCP 47.
+** [[Lexical Markup Framework]]: ISO specification for representation of machine-readable dictionaries.
+** [[Unicode]]'s [[CLDR|Common locale data repository]]: Uses several hundred codes from ISO 639-3 not included in ISO 639-2.
+

--- a/Standards used in Language Technology.md
+++ b/Standards used in Language Technology.md
@@ -1,6 +1,6 @@
 #Standards used in Language Technology and Lingusitics
 
-##Language Identification
+##Language and Language Family Identification
 * ISO 639-1
 * ISO 639-2
 * ISO 639-3
@@ -12,29 +12,24 @@
 * BCP 47: [Best Current Practice 47](https://tools.ietf.org/html/bcp47), which includes RFC 5646
 * RFC 5646, which superseded RFC 4646, which superseded [RFC 3066](https://www.ietf.org/rfc/rfc3066.txt). (Therefore all standards which depend on any of these 3 IETF standards now use ISO 639-3.)
 
+##Script Identification Standards
 
-Text Encoding Initiative (TEI):[29] via IETF's BCP 47.
-Lexical Markup Framework: ISO specification for representation of machine-readable dictionaries.
-Unicode's Common locale data repository: Uses several hundred codes from ISO 639-3 not included in ISO 639-2.
-
-##Script Identification
-
-##Metadata
+##Metadata Standards
 * OLAC 1.1 [OLAC: the Open Languages Archive Community](http://www.language-archives.org/REC/language.html)
-* Dublin Core Metadata Initiative: DCMI Metadata Term for language, via IETF's RFC 4646 (now superseded by RFC 5646)
-* HTML5:[27] via IETF's BCP 47.
+* Dublin Core Metadata Initiative: DCMI Metadata Term(http://purl.org/dc/elements/1.1/language) for language, via IETF's RFC 4646 (now superseded by RFC 5646)
 * MARC library codes.
 * MODS (Metadata Object Description Schema) [library codes](http://www.loc.gov/standards/mods/v3/mods-userguide-elements.html): Incorporates IETF's RFC 3066 (now superseded by RFC 5646).
 
+## i18n / Locale data
+* Unicode's CLDR (Common locale data repository): Uses several hundred codes from ISO 639-3 not included in ISO 639-2.
 
-* Other standards that rely on ISO 639-3:
-** [[IETF language tag|Language tags]] as defined by the [[IETF|Internet Engineering Task Force (IETF)]], as documented in:
-*** RFC 5646, which superseded RFC 4646, which superseded [https://www.ietf.org/rfc/rfc3066.txt RFC 3066]. (Therefore all standards which depend on any of these 3 IETF standards now use ISO 639-3.)
-** [[Dublin Core|Dublin Core Metadata Initiative]]: DCMI Metadata Term<ref>http://purl.org/dc/elements/1.1/language</ref> for language, via IETF's RFC 4646 (now superseded by RFC 5646).
-** HTML5:<ref>http://www.w3.org/TR/html5/dom.html#the-lang-and-xml:lang-attributes</ref> via IETF's BCP 47.
-** [[MARC standards|MARC]] library codes.
-** [[Metadata Object Description Schema|MODS]] library codes:<ref>http://www.loc.gov/standards/mods/v3/mods-userguide-elements.html</ref> Incorporates IETF's [https://www.ietf.org/rfc/rfc3066.txt RFC 3066] (now superseded by RFC 5646).
-** Text Encoding Initiative (TEI):<ref>http://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-language.html</ref> via IETF's BCP 47.
-** [[Lexical Markup Framework]]: ISO specification for representation of machine-readable dictionaries.
-** [[Unicode]]'s [[CLDR|Common locale data repository]]: Uses several hundred codes from ISO 639-3 not included in ISO 639-2.
+##Text Markup Formats
+
+###Documents
+* [HTML5](http://www.w3.org/TR/html5/dom.html#the-lang-and-xml:lang-attributes): via IETF's BCP 47.
+* Text Encoding Initiative [TEI](http://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-language.html) via IETF's BCP 47.
+
+###Corpora
+###Lexicons
+* Lexical Markup Framework: ISO specification for representation of machine-readable dictionaries.
 


### PR DESCRIPTION
@RichardLitt It occurs to me that, while the repo seems to have a good handle on software there there is no place for standards. I put these in a separate list for now, but thought that it might be of interest to keep then together. Not that we would need to have the same actions on both but, Devs may be just as desirous of both items. It’s a large commit because it is the first commit. As I have been doing my work it has always been a hassle to figure out what is the BCP or the latest in a series of developments (either for OS X or Windows or Linux). If you don't think this fits scope let me know and I will keep it in a separate repo. If you create an organization (on github) maybe the repo can move.