### PR TITLE
encouraging visitors to star projects they like

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ Looking for resources for code languages? Take a look at [the awesome collection
 
 ##Single language lexicography projects and utilities
 ###Utilities
-* [DictionaryChromeExtension](https://github.com/OpenSourceFieldlinguistics/DictionaryChromeExtension) Dictionary for websites in low-resource languages. App and codebase which connects to a Wiktionary to provide definitions of any term on any website (current languages Cherokee 194,426 entries, Inuktitut 251 entries, Kartuli 7,363 entries, Plains Cree (incubation) 0 entries)
+* [DictionaryChromeExtension ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/DictionaryChromeExtension.svg)](https://github.com/OpenSourceFieldlinguistics/DictionaryChromeExtension)  Dictionary for websites in low-resource languages. App and codebase which connects to a Wiktionary to provide definitions of any term on any website (current languages Cherokee 194,426 entries, Inuktitut 251 entries, Kartuli 7,363 entries, Plains Cree (incubation) 0 entries)
 * [Project for Free Electronic Dictionaries](http://pfed.info/) Is a project for a java MIDlet for mobile phones - for indigenous language dictionaries.
 * [Webonary](http://www.Webonary.org) Site which hosts digital dictionaries for single languages.
-* [WeSay](https://github.com/sillsdev/wesay) Allows language communities to build their own dictionaries. http://wesay.org (by the SIL International)
+* [WeSay ![GitHub stars](https://img.shields.io/github/stars/sillsdev/wesay.svg)](https://github.com/sillsdev/wesay)  Allows language communities to build their own dictionaries. http://wesay.org (by the SIL International)
 
 ###Interactions and presentations of data
 * [Dict.cc](http://www.dict.cc/) An exlimpar model of a successful bilingual (German-English) dictionary as it has grown from a hobby to a business employing 22 people.
@@ -108,104 +108,104 @@ Looking for resources for code languages? Take a look at [the awesome collection
 ##Software
 * [accentuate.us](http://sourceforge.net/p/lingala/code/HEAD/tree/) a.k.a. "charlifter". Statistical Unicodification of plain text for many languages
 * [AGTK](http://sourceforge.net/projects/agtk/) AGTK is a suite of software components for building tools for annotating linguistic signals, time-series data which documents any kind of linguistic behavior (e.g. audio, video). The internal data structures are based on annotation graphs.
-* [Anki](https://github.com/dae/anki) Anki is a program to make and share flaschard decks (including audio) for any language or writing system. http://ankisrs.net/
+* [Anki ![GitHub stars](https://img.shields.io/github/stars/dae/anki.svg)](https://github.com/dae/anki)  Anki is a program to make and share flaschard decks (including audio) for any language or writing system. http://ankisrs.net/
 * [ANNIS](http://www.sfb632.uni-potsdam.de/annis/index.html) Search and Visualization in Multilayer Linguistic Corpora
 * [Apertium](http://sourceforge.net/projects/apertium/) Apertium is a toolbox to build open-source shallow-transfer machine translation systems, especially suitable for related language pairs: it includes the engine, maintenance tools, and open linguistic data for several language pairs.
-* [ark-tweet-nlp](https://github.com/OpenSourceFieldlinguistics/ark-tweet-nlp) CMU ARK Twitter Part-of-Speech Tagger (_Fork_)
-* [bayesline](https://github.com/alvations/bayesline) A Multinomial Bayesian Classification for Language Identification
-* [BloomDesktop](https://github.com/BloomBooks/BloomDesktop) Bloom Desktop is a hybrid c#/javascript/html/css Windows application that dramatically "lowers the bar" for language communities who want books in their own languages. Bloom delivers a low-training, high-output system where mother tongue speakers and their advocates work together to foster both community authorship and access to external materia… http://bloomlibrary.org/
-* [brain](https://github.com/OpenSourceFieldlinguistics/brain) Neural networks in JavaScript
-* [cdec](https://github.com/redpony/cdec) Decoder, aligner, and model optimizer for statistical machine translation and other structured prediction models based on (mostly) context-free formalisms http://cdec-decoder.org/
+* [ark-tweet-nlp ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/ark-tweet-nlp.svg)](https://github.com/OpenSourceFieldlinguistics/ark-tweet-nlp)  CMU ARK Twitter Part-of-Speech Tagger (_Fork_)
+* [bayesline ![GitHub stars](https://img.shields.io/github/stars/alvations/bayesline.svg)](https://github.com/alvations/bayesline)  A Multinomial Bayesian Classification for Language Identification
+* [BloomDesktop ![GitHub stars](https://img.shields.io/github/stars/BloomBooks/BloomDesktop.svg)](https://github.com/BloomBooks/BloomDesktop)  Bloom Desktop is a hybrid c#/javascript/html/css Windows application that dramatically "lowers the bar" for language communities who want books in their own languages. Bloom delivers a low-training, high-output system where mother tongue speakers and their advocates work together to foster both community authorship and access to external materia… http://bloomlibrary.org/
+* [brain ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/brain.svg)](https://github.com/OpenSourceFieldlinguistics/brain)  Neural networks in JavaScript
+* [cdec ![GitHub stars](https://img.shields.io/github/stars/redpony/cdec.svg)](https://github.com/redpony/cdec)  Decoder, aligner, and model optimizer for statistical machine translation and other structured prediction models based on (mostly) context-free formalisms http://cdec-decoder.org/
 * [charlint](http://www.w3.org/International/charlint/) Charlint is a character normalization/checking tool written in Perl. Among else, it implements Normalization Form C of Unicode TR 15, as a test platform for Early Uniform Normalization in the W3C Character Model.
-* [clam](https://github.com/proycon/clam) Computational Linguistics Application Mediator -- Quickly turn NLP applications into RESTful webservices with a web-application front-end. You provide a specification of your command line application, its input, output and parameters, and CLAM wraps around your application to form a fully fledged RESTful webservice.
-* [clld](https://github.com/clld/clld) The `clld` python package is a toolkit to build cross-linguistic databases. A list of databases built with it is available at http://clld.org/datasets.html
-* [Cog](https://github.com/sillsdev/cog) Cog is a tool for comparing languages using lexicostatistics and comparative linguistics techniques. It can be used to automate much of the process of comparing word lists from different language varieties. http://sillsdev.github.io/cog/
-* [CorpusTools](https://github.com/PhonologicalCorpusTools/CorpusTools) Phonological CorpusTools http://phonologicalcorpustools.github.io/CorpusTools/
+* [clam ![GitHub stars](https://img.shields.io/github/stars/proycon/clam.svg)](https://github.com/proycon/clam)  Computational Linguistics Application Mediator -- Quickly turn NLP applications into RESTful webservices with a web-application front-end. You provide a specification of your command line application, its input, output and parameters, and CLAM wraps around your application to form a fully fledged RESTful webservice.
+* [clld ![GitHub stars](https://img.shields.io/github/stars/clld/clld.svg)](https://github.com/clld/clld)  The `clld` python package is a toolkit to build cross-linguistic databases. A list of databases built with it is available at http://clld.org/datasets.html
+* [Cog ![GitHub stars](https://img.shields.io/github/stars/sillsdev/cog.svg)](https://github.com/sillsdev/cog)  Cog is a tool for comparing languages using lexicostatistics and comparative linguistics techniques. It can be used to automate much of the process of comparing word lists from different language varieties. http://sillsdev.github.io/cog/
+* [CorpusTools ![GitHub stars](https://img.shields.io/github/stars/PhonologicalCorpusTools/CorpusTools.svg)](https://github.com/PhonologicalCorpusTools/CorpusTools)  Phonological CorpusTools http://phonologicalcorpustools.github.io/CorpusTools/
 * [CTK](http://champollion.sourceforge.net/) Built around LDC's champollion sentence aligner kernel, Champollion Tool Kit (CTK) aims to providing ready-to-use parallel text sentence alignment tools for as many language pairs as possible.
 * [CuPED](http://sweet.artsrn.ualberta.ca/cdcox/cuped/) CuPED ('Customizable Presentation of ELAN Documents') is a tool for transforming time-aligned transcripts, such as those produced by ELAN, into a variety of presentation formats.
-* [DataTags](https://github.com/OpenSourceFieldlinguistics/DataTags) A system to assess the sensitivity and privacy risk of a dataset, and assign a tag to describe how the dataset must be transfered, stored and accessed. (_Fork_)
-* [dataverse](https://github.com/IQSS/dataverse) A data repository framework to share and publish research data.
-* [dative](https://github.com/jrwdunham/dative) A single-page application that interacts with multiple linguistic fieldwork web service databases.
-* [DeepLearnToolbox](https://github.com/OpenSourceFieldlinguistics/DeepLearnToolbox) Matlab/Octave toolbox for deep learning. Includes Deep Belief Nets, Stacked Autoencoders, Convolutional Neural Nets, Convolutional Autoencoders and vanilla Neural Nets. Each method has examples to get you started.
-* [Desmeme](https://github.com/jcgood/desmeme) Database and tools for exploring linguistic templates
-* [dictdb](https://github.com/substack/dictdb) dictionary database for language translation
-* [discoursegraphs](https://github.com/arne-cl/discoursegraphs) Python-based tool to convert and merge multilayer annotated linguistic data
-* [DLTK](https://github.com/alvations/DLTK) Deutsch Language Tool Kit http://goo.gl/wdnz1W
+* [DataTags ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/DataTags.svg)](https://github.com/OpenSourceFieldlinguistics/DataTags)  A system to assess the sensitivity and privacy risk of a dataset, and assign a tag to describe how the dataset must be transfered, stored and accessed. (_Fork_)
+* [dataverse ![GitHub stars](https://img.shields.io/github/stars/IQSS/dataverse.svg)](https://github.com/IQSS/dataverse)  A data repository framework to share and publish research data.
+* [dative ![GitHub stars](https://img.shields.io/github/stars/jrwdunham/dative.svg)](https://github.com/jrwdunham/dative)  A single-page application that interacts with multiple linguistic fieldwork web service databases.
+* [DeepLearnToolbox ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/DeepLearnToolbox.svg)](https://github.com/OpenSourceFieldlinguistics/DeepLearnToolbox)  Matlab/Octave toolbox for deep learning. Includes Deep Belief Nets, Stacked Autoencoders, Convolutional Neural Nets, Convolutional Autoencoders and vanilla Neural Nets. Each method has examples to get you started.
+* [Desmeme ![GitHub stars](https://img.shields.io/github/stars/jcgood/desmeme.svg)](https://github.com/jcgood/desmeme)  Database and tools for exploring linguistic templates
+* [dictdb ![GitHub stars](https://img.shields.io/github/stars/substack/dictdb.svg)](https://github.com/substack/dictdb)  dictionary database for language translation
+* [discoursegraphs ![GitHub stars](https://img.shields.io/github/stars/arne-cl/discoursegraphs.svg)](https://github.com/arne-cl/discoursegraphs)  Python-based tool to convert and merge multilayer annotated linguistic data
+* [DLTK ![GitHub stars](https://img.shields.io/github/stars/alvations/DLTK.svg)](https://github.com/alvations/DLTK)  Deutsch Language Tool Kit http://goo.gl/wdnz1W
 * [ELAN](https://tla.mpi.nl/tools/tla-tools/elan/) ELAN is a professional tool for the creation of complex annotations on video and audio resources.
-* [ELDER: Endangered Language Data Electronic Repository](https://github.com/elderonline/ELDER) Endangered Language Data Electronic Repository: A web-based ontologically-compliant collaborative linguistic data cataloguing tool.
+* [ELDER: Endangered Language Data Electronic Repository ![GitHub stars](https://img.shields.io/github/stars/elderonline/ELDER.svg)](https://github.com/elderonline/ELDER)  Endangered Language Data Electronic Repository: A web-based ontologically-compliant collaborative linguistic data cataloguing tool.
 * [EMMA](http://www.cs.bris.ac.uk/Research/MachineLearning/Morphology/resources.jsp#eval) A Novel Evaluation Metric for Morphological Analysis
-* [eopas](https://github.com/eopas/eopas) ETHNOER Online Presentation and Annotation System
-* [FieldWorks](https://github.com/sillsdev/FieldWorks) FieldWorks is a suite of software tools for language and cultural data, with support for complex scripts. http://fieldworks.sil.org/
-* [FLEx / FieldWorks](https://github.com/sillsdev/FieldWorks) FieldWorks is popular a suite of software tools for language and cultural data, with support for complex scripts. http://fieldworks.sil.org/ FieldWorks Language Explorer (or FLEx, for short) is designed to help field linguists perform many common language documentation and analysis tasks. It can help you: elicit and record lexical information, create dictionaries, interlinearize texts, analyze discourse features, study morphology
-* [Gaia](https://github.com/mozilla-b2g/gaia/) Gaia is a HTML5-based Phone UI for the Boot 2 Gecko Project. NOTE: For details of what branches are used for what releases, see https://wiki.mozilla.org/B2G. If you're interested in setting up a keyboard in new language, see [this](https://developer.mozilla.org/en-US/Firefox_OS/Developing_Gaia/Customizing_the_keyboard).
-* [Glottolog data](https://github.com/clld/glottolog-data) [Glottolog](http://glottolog.org) provides comprehensive reference information for the world's languages. The data published in Glottolog is curated in https://github.com/clld/glottolog-data
-* [graf-python](https://github.com/cidles/graf-python) The library graf-python is an open source Python implemenation to parse and write GrAF/XML files as described in ISO 24612. The parser of the library creates an annotation graph from the files. The user may then query the annotation graph via the API of graf-python.
+* [eopas ![GitHub stars](https://img.shields.io/github/stars/eopas/eopas.svg)](https://github.com/eopas/eopas)  ETHNOER Online Presentation and Annotation System
+* [FieldWorks ![GitHub stars](https://img.shields.io/github/stars/sillsdev/FieldWorks.svg)](https://github.com/sillsdev/FieldWorks)  FieldWorks is a suite of software tools for language and cultural data, with support for complex scripts. http://fieldworks.sil.org/
+* [FLEx / FieldWorks ![GitHub stars](https://img.shields.io/github/stars/sillsdev/FieldWorks.svg)](https://github.com/sillsdev/FieldWorks)  FieldWorks is popular a suite of software tools for language and cultural data, with support for complex scripts. http://fieldworks.sil.org/ FieldWorks Language Explorer (or FLEx, for short) is designed to help field linguists perform many common language documentation and analysis tasks. It can help you: elicit and record lexical information, create dictionaries, interlinearize texts, analyze discourse features, study morphology
+* [Gaia ![GitHub stars](https://img.shields.io/github/stars/mozilla-b2g/gaia.svg)](https://github.com/mozilla-b2g/gaia)  Gaia is a HTML5-based Phone UI for the Boot 2 Gecko Project. NOTE: For details of what branches are used for what releases, see https://wiki.mozilla.org/B2G. If you're interested in setting up a keyboard in new language, see [this](https://developer.mozilla.org/en-US/Firefox_OS/Developing_Gaia/Customizing_the_keyboard).
+* [Glottolog data ![GitHub stars](https://img.shields.io/github/stars/clld/glottolog-data.svg)](https://github.com/clld/glottolog-data)  [Glottolog](http://glottolog.org) provides comprehensive reference information for the world's languages. The data published in Glottolog is curated in https://github.com/clld/glottolog-data
+* [graf-python ![GitHub stars](https://img.shields.io/github/stars/cidles/graf-python.svg)](https://github.com/cidles/graf-python)  The library graf-python is an open source Python implemenation to parse and write GrAF/XML files as described in ISO 24612. The parser of the library creates an annotation graph from the files. The user may then query the annotation graph via the API of graf-python.
 * [Gramadóir](http://sourceforge.net/projects/gramadoir/) Grammar checking engine that is designed for the rapid development of grammar checkers for minority languages and other languages with limited computational resources.
-* [https://github.com/hyphenliu/cnminlangwebcollect](https://github.com/hyphenliu/cnminlangwebcollect) Chinese minorities website languages detection and websites collection
-* [https://github.com/leebock/languages](https://github.com/leebock/languages) Application files for the Smithsonian endangered languages story map.
-* [iLanguageCloud](https://github.com/OpenSourceFieldlinguistics/iLanguageCloud) An HTML5/Android word cloud generation codebase
-* [itweets-geodata](https://github.com/kscanne/itweets-geodata) Geodata from Indigenous Tweets
-* [koreksyon](https://github.com/reokatoa/koreksyon) Tools for developing and implementing spell-checking and grammar-checking capabilities in low-resource languages
-* [l20n.js](https://github.com/l20n/l20n.js) L20n reinvents software localization. Users should be able to benefit from the entire expressive power of natural languages. L20n keeps simple things simple, and at the same time makes complex things possible. This is the JavaScript implementation of L20n. http://l20n.org
+* [https://github.com/hyphenliu/cnminlangwebcollect ![GitHub stars](https://img.shields.io/github/stars/hyphenliu/cnminlangwebcollect.svg)](https://github.com/hyphenliu/cnminlangwebcollect)  Chinese minorities website languages detection and websites collection
+* [https://github.com/leebock/languages ![GitHub stars](https://img.shields.io/github/stars/leebock/languages.svg)](https://github.com/leebock/languages)  Application files for the Smithsonian endangered languages story map.
+* [iLanguageCloud ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/iLanguageCloud.svg)](https://github.com/OpenSourceFieldlinguistics/iLanguageCloud)  An HTML5/Android word cloud generation codebase
+* [itweets-geodata ![GitHub stars](https://img.shields.io/github/stars/kscanne/itweets-geodata.svg)](https://github.com/kscanne/itweets-geodata)  Geodata from Indigenous Tweets
+* [koreksyon ![GitHub stars](https://img.shields.io/github/stars/reokatoa/koreksyon.svg)](https://github.com/reokatoa/koreksyon)  Tools for developing and implementing spell-checking and grammar-checking capabilities in low-resource languages
+* [l20n.js ![GitHub stars](https://img.shields.io/github/stars/l20n/l20n.js.svg)](https://github.com/l20n/l20n.js)  L20n reinvents software localization. Users should be able to benefit from the entire expressive power of natural languages. L20n keeps simple things simple, and at the same time makes complex things possible. This is the JavaScript implementation of L20n. http://l20n.org
 * [langtech](https://victorio.uit.no/langtech/trunk/) A host of resources provided in SVN by the University of Tromsø. Details are [here](http://giellatekno.uit.no) and in English [here](http://giellatekno.uit.no/index.eng.html).
 * [LDC Word Aligner](https://www.ldc.upenn.edu/language-resources/tools/ldc-word-aligner) LDC Word Aligner is a software tool used for manual annotation of word alignment developed to support Arabic-English and Chinese-English word alignment tasks. It has a clean, easy-to-use interface. Since its development in 2009, LDC has used LDC Word Aligner to generate over 1,000,000 tokens of annotated word alignment data from a variety of genres including broadcast, newswire and web-based sources.
-* [LEGO Unified Concepticon](https://github.com/jcgood/concepticon) Material relating to the LEGO Unified Concepticon
-* [Lex4All](https://github.com/lex4all/lex4all) pronunciation LEXicons for Any Low-resource Language http://lex4all.github.io/lex4all/
+* [LEGO Unified Concepticon ![GitHub stars](https://img.shields.io/github/stars/jcgood/concepticon.svg)](https://github.com/jcgood/concepticon)  Material relating to the LEGO Unified Concepticon
+* [Lex4All ![GitHub stars](https://img.shields.io/github/stars/lex4all/lex4all.svg)](https://github.com/lex4all/lex4all)  pronunciation LEXicons for Any Low-resource Language http://lex4all.github.io/lex4all/
 * [LinGO Grammar Matrix](http://www.delph-in.net/matrix/) The LinGO Grammar Matrix is a framework for the development of broad-coverage, precision, implemented grammars for diverse languages.
-* [Lingpy](https://github.com/lingpy/lingpy) LingPy: Python library for quantitative tasks in historical linguistics http://lingpy.org
+* [Lingpy ![GitHub stars](https://img.shields.io/github/stars/lingpy/lingpy.svg)](https://github.com/lingpy/lingpy)  LingPy: Python library for quantitative tasks in historical linguistics http://lingpy.org
 * [Linguistica](http://linguistica.uchicago.edu/downloads.html) Linguistica is a program designed to explore the unsupervised learning of natural language, with primary focus on morphology (word-structure). It runs under Windows, Mac OS X and Linux, and is written in C++ within the Qt development framework. Its demands on memory depend on the size of the corpus analyzed.
-* [lrl](https://github.com/RichardLitt/lrl) For work concerning low resource languages.
-* [Machine](https://github.com/sillsdev/machine) Machine is a natural language processing library for .NET that is focused on providing tools for processing resource-poor languages (used by FLEx)
-* [Make-extensions](https://github.com/kscanne/make-extensions) Scripts for generating hunspell spellchecking extensions
+* [lrl ![GitHub stars](https://img.shields.io/github/stars/RichardLitt/lrl.svg)](https://github.com/RichardLitt/lrl)  For work concerning low resource languages.
+* [Machine ![GitHub stars](https://img.shields.io/github/stars/sillsdev/machine.svg)](https://github.com/sillsdev/machine)  Machine is a natural language processing library for .NET that is focused on providing tools for processing resource-poor languages (used by FLEx)
+* [Make-extensions ![GitHub stars](https://img.shields.io/github/stars/kscanne/make-extensions.svg)](https://github.com/kscanne/make-extensions)  Scripts for generating hunspell spellchecking extensions
 * [Minority Translate](https://bitbucket.org/andrjus/minoritytranslate/) Minority Translate is a simple program for helping content generation on smaller sized Wikipedias (actually any sized) by giving pointers to existing articles in other language Wikipedias, so that the user can easily translate or adapt existing texts and thus increase the size and useability of their Wikipedia editions.
-* [morfessor](https://github.com/aalto-speech/morfessor) Morfessor is a tool for unsupervised and semi-supervised morphological segmentation
-* [moz-l10n-tiers](https://github.com/kscanne/moz-l10n-tiers) Creates a pseudo-locale to evaluate string prioritization for l10n
-* [Natural](https://github.com/NaturalNode/natural) *Javascript* general natural language facilities for node
+* [morfessor ![GitHub stars](https://img.shields.io/github/stars/aalto-speech/morfessor.svg)](https://github.com/aalto-speech/morfessor)  Morfessor is a tool for unsupervised and semi-supervised morphological segmentation
+* [moz-l10n-tiers ![GitHub stars](https://img.shields.io/github/stars/kscanne/moz-l10n-tiers.svg)](https://github.com/kscanne/moz-l10n-tiers)  Creates a pseudo-locale to evaluate string prioritization for l10n
+* [Natural ![GitHub stars](https://img.shields.io/github/stars/NaturalNode/natural.svg)](https://github.com/NaturalNode/natural)  *Javascript* general natural language facilities for node
 * [NIST 2008 Open Machine Translation Evalutation](https://catalog.ldc.upenn.edu/LDC2010T21)
-* [NLTK](https://github.com/nltk/nltk) *Python* Natural Language Tool Kit. NLTK Source http://nltk.github.com/
-* [node-panlex](https://github.com/longnow/node-panlex) node.js client for PanLex
-* [norma](https://github.com/fpetran/norma) A tool for automatic spelling normalization
-* [octothorpe](https://github.com/OpenSourceFieldlinguistics/octothorpe) CouchDB-powered wiki thing
+* [NLTK ![GitHub stars](https://img.shields.io/github/stars/nltk/nltk.svg)](https://github.com/nltk/nltk)  *Python* Natural Language Tool Kit. NLTK Source http://nltk.github.com/
+* [node-panlex ![GitHub stars](https://img.shields.io/github/stars/longnow/node-panlex.svg)](https://github.com/longnow/node-panlex)  node.js client for PanLex
+* [norma ![GitHub stars](https://img.shields.io/github/stars/fpetran/norma.svg)](https://github.com/fpetran/norma)  A tool for automatic spelling normalization
+* [octothorpe ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/octothorpe.svg)](https://github.com/OpenSourceFieldlinguistics/octothorpe)  CouchDB-powered wiki thing
 * [ogoki](http://www.ogokilearning.com/native-language-app-code/) iPhone & iPad template source code (as a .zip) for language learning
-* [old-webapp](https://github.com/jrwdunham/old-webapp) Online Linguistic Database --- software for creating web applications to collaboratively document languages.http://www.onlinelinguisticdatabase.org
+* [old-webapp ![GitHub stars](https://img.shields.io/github/stars/jrwdunham/old-webapp.svg)](https://github.com/jrwdunham/old-webapp)  Online Linguistic Database --- software for creating web applications to collaboratively document languages.http://www.onlinelinguisticdatabase.org
 * [OpenDataKit](http://opendatakit.org/downloads/) Open Data Kit (ODK) is an open-source suite of tools that helps organizations author, field, and manage mobile data collection solutions
-* [panlex-tools](https://github.com/longnow/panlex-tools) This package contains scripts to transform lexical resources into a format suitable for importing into PanLex. Documentation may be found at http://dev.panlex.org/tools/
-* [pepper](https://github.com/korpling/pepper) Pepper is a pluggable, Java-based, open source converter framework for linguistic data.
-* [poio-analyzer](https://github.com/cidles/poio-analyzer) Poio is a collection of software tools for linguists working in language documentation, descriptive linguistics and/or language typology. It allows linguists to manage and analyze their data. The Poio Interlinear Editor allows to add morpho-syntactic annotations to transcriptions. It supports various file formats for input, but will only output standardized XML defined by the Corpus Encoding Standard and the Text Encoding Initiative. Several tools for analyzing linguistic data will be made available to further process annotated data. Poio tools are written in Python and are based on PyQt.
-* [poio-api](https://github.com/cidles/poio-api) Poio API is a free and open source Python library to access and search data from language documentation in your linguistic analysis workflow. It converts file formats like Elan’s EAF, Toolbox files, Typecraft XML and others into annotation graphs as defined in ISO 24612. Those graphs, for which we use an implementation called “Graph Annotation F… http://media.cidles.eu/poio/poio-api
-* [poio-corpus](https://github.com/cidles/poio-corpus) The Poio Corpus is a freely available collection of language resources for the lesser-used languages. The data is extracted from free sources like Wikipedia, dictionaries, documents, websites and others.
-* [poio-doc](https://github.com/cidles/poio-doc) Documentation of the Poio project.http://www.poio.eu
-* [poio-site](https://github.com/cidles/poio-site) The website of the Poio project - http://www.poio.eu
-* [pressagio](https://github.com/cidles/pressagio) Pressagio is a library that predicts text based on n-gram models. For example, you can send a string and the library will return the most likely word completions for the last token in the string.
-* [pyannotation](https://github.com/cidles/pyannotation) PyAnnotation is a Python Library to access and manipulate linguistically annotated corpus files.
-* [PyAnnotationGraph](https://github.com/PhonologicalCorpusTools/PyAnnotationGraph) Implement the formal model for linguistic annotations described in Bird and Liberman (2001) using Python and SQL
-* [pyDelphin](https://github.com/goodmami/pydelphin) Python libraries for DELPH-IN (Friendly Fork)
-* [Rosetta Pangloss](https://github.com/jcgood/rosetta-pangloss) The Rosetta Project's Pangloss system
-* [Salt](https://github.com/korpling/salt) A graph-based model to store and manipulate linguistic data.
-* [Secwepemc-Facebook](https://github.com/kscanne/secwepemc-facebook) Translate Facebook into unsupported languages
-* [SeedLing](https://github.com/alvations/SeedLing) Building and Using A Seed Corpus for the Human Language Project
+* [panlex-tools ![GitHub stars](https://img.shields.io/github/stars/longnow/panlex-tools.svg)](https://github.com/longnow/panlex-tools)  This package contains scripts to transform lexical resources into a format suitable for importing into PanLex. Documentation may be found at http://dev.panlex.org/tools/
+* [pepper ![GitHub stars](https://img.shields.io/github/stars/korpling/pepper.svg)](https://github.com/korpling/pepper)  Pepper is a pluggable, Java-based, open source converter framework for linguistic data.
+* [poio-analyzer ![GitHub stars](https://img.shields.io/github/stars/cidles/poio-analyzer.svg)](https://github.com/cidles/poio-analyzer)  Poio is a collection of software tools for linguists working in language documentation, descriptive linguistics and/or language typology. It allows linguists to manage and analyze their data. The Poio Interlinear Editor allows to add morpho-syntactic annotations to transcriptions. It supports various file formats for input, but will only output standardized XML defined by the Corpus Encoding Standard and the Text Encoding Initiative. Several tools for analyzing linguistic data will be made available to further process annotated data. Poio tools are written in Python and are based on PyQt.
+* [poio-api ![GitHub stars](https://img.shields.io/github/stars/cidles/poio-api.svg)](https://github.com/cidles/poio-api)  Poio API is a free and open source Python library to access and search data from language documentation in your linguistic analysis workflow. It converts file formats like Elan’s EAF, Toolbox files, Typecraft XML and others into annotation graphs as defined in ISO 24612. Those graphs, for which we use an implementation called “Graph Annotation F… http://media.cidles.eu/poio/poio-api
+* [poio-corpus ![GitHub stars](https://img.shields.io/github/stars/cidles/poio-corpus.svg)](https://github.com/cidles/poio-corpus)  The Poio Corpus is a freely available collection of language resources for the lesser-used languages. The data is extracted from free sources like Wikipedia, dictionaries, documents, websites and others.
+* [poio-doc ![GitHub stars](https://img.shields.io/github/stars/cidles/poio-doc.svg)](https://github.com/cidles/poio-doc)  Documentation of the Poio project.http://www.poio.eu
+* [poio-site ![GitHub stars](https://img.shields.io/github/stars/cidles/poio-site.svg)](https://github.com/cidles/poio-site)  The website of the Poio project - http://www.poio.eu
+* [pressagio ![GitHub stars](https://img.shields.io/github/stars/cidles/pressagio.svg)](https://github.com/cidles/pressagio)  Pressagio is a library that predicts text based on n-gram models. For example, you can send a string and the library will return the most likely word completions for the last token in the string.
+* [pyannotation ![GitHub stars](https://img.shields.io/github/stars/cidles/pyannotation.svg)](https://github.com/cidles/pyannotation)  PyAnnotation is a Python Library to access and manipulate linguistically annotated corpus files.
+* [PyAnnotationGraph ![GitHub stars](https://img.shields.io/github/stars/PhonologicalCorpusTools/PyAnnotationGraph.svg)](https://github.com/PhonologicalCorpusTools/PyAnnotationGraph)  Implement the formal model for linguistic annotations described in Bird and Liberman (2001) using Python and SQL
+* [pyDelphin ![GitHub stars](https://img.shields.io/github/stars/goodmami/pydelphin.svg)](https://github.com/goodmami/pydelphin)  Python libraries for DELPH-IN (Friendly Fork)
+* [Rosetta Pangloss ![GitHub stars](https://img.shields.io/github/stars/jcgood/rosetta-pangloss.svg)](https://github.com/jcgood/rosetta-pangloss)  The Rosetta Project's Pangloss system
+* [Salt ![GitHub stars](https://img.shields.io/github/stars/korpling/salt.svg)](https://github.com/korpling/salt)  A graph-based model to store and manipulate linguistic data.
+* [Secwepemc-Facebook ![GitHub stars](https://img.shields.io/github/stars/kscanne/secwepemc-facebook.svg)](https://github.com/kscanne/secwepemc-facebook)  Translate Facebook into unsupported languages
+* [SeedLing ![GitHub stars](https://img.shields.io/github/stars/alvations/SeedLing.svg)](https://github.com/alvations/SeedLing)  Building and Using A Seed Corpus for the Human Language Project
 * [Skype in your language](http://sourceforge.net/projects/skypeinyourlang/) Translate Skype into unsupported languages
 * [SPHERE Conversion Tools](https://www.ldc.upenn.edu/language-resources/tools/sphere-conversion-tools) Many LDC corpora contain speech files in NIST SPHERE format. The programs below convert SPHERE files to other formats.
-* [Stanford CoreNLP Python](https://github.com/dasmith/stanford-corenlp-python) Python wrapper for Stanford CoreNLP tools
-* [sugali](https://github.com/alvations/sugali) This is a legacy repository of the language identification project for many (many) languages project for the software project course, NLP projects for low-resource languages.
-* [SuGarLike](https://github.com/alvations/SuGarLike) Language Identification for Low Resource Languages (by Susanne, Guy and Liling)
-* [TeraDict](https://github.com/longnow/TeraDict) Translate English words into hundreds of languages!
-* [TexNLP](https://github.com/utcompling/texnlp) TexNLP: Texas Natural Language Processing tools
-* [Toney](https://github.com/langtech/toney) Tone Classification Software
-* [Toolbox Scripts for ELAN](https://github.com/RichardLitt/toolbox-scripts) Mirror of Alexander Koenig's Toolbox Scripts https://tla.mpi.nl/tools/tla-tools/elan/thirdparty/
-* [ToolsForFieldLinguistics](https://github.com/cesine/ToolsForFieldLinguistics) A collection of scripts and recipes for linguistics
-* [translitit-engine](https://github.com/OpenSourceFieldlinguistics/translitit-engine) A transliteration engine written in JavaScript
-* [Tsammalex data](https://github.com/clld/tsammalex-data) [Tsammalex](http://tsammalex.clld.org) is a multilingual lexical database on plants and animals. The data published on the Tsammalex website is curated collaboratively at https://github.com/clld/tsammalex-data
-* [tweet2learn](https://github.com/kscanne/tweet2learn) An app to make it easier to use your native language on Twitter
+* [Stanford CoreNLP Python ![GitHub stars](https://img.shields.io/github/stars/dasmith/stanford-corenlp-python.svg)](https://github.com/dasmith/stanford-corenlp-python)  Python wrapper for Stanford CoreNLP tools
+* [sugali ![GitHub stars](https://img.shields.io/github/stars/alvations/sugali.svg)](https://github.com/alvations/sugali)  This is a legacy repository of the language identification project for many (many) languages project for the software project course, NLP projects for low-resource languages.
+* [SuGarLike ![GitHub stars](https://img.shields.io/github/stars/alvations/SuGarLike.svg)](https://github.com/alvations/SuGarLike)  Language Identification for Low Resource Languages (by Susanne, Guy and Liling)
+* [TeraDict ![GitHub stars](https://img.shields.io/github/stars/longnow/TeraDict.svg)](https://github.com/longnow/TeraDict)  Translate English words into hundreds of languages!
+* [TexNLP ![GitHub stars](https://img.shields.io/github/stars/utcompling/texnlp.svg)](https://github.com/utcompling/texnlp)  TexNLP: Texas Natural Language Processing tools
+* [Toney ![GitHub stars](https://img.shields.io/github/stars/langtech/toney.svg)](https://github.com/langtech/toney)  Tone Classification Software
+* [Toolbox Scripts for ELAN ![GitHub stars](https://img.shields.io/github/stars/RichardLitt/toolbox-scripts.svg)](https://github.com/RichardLitt/toolbox-scripts)  Mirror of Alexander Koenig's Toolbox Scripts https://tla.mpi.nl/tools/tla-tools/elan/thirdparty/
+* [ToolsForFieldLinguistics ![GitHub stars](https://img.shields.io/github/stars/cesine/ToolsForFieldLinguistics.svg)](https://github.com/cesine/ToolsForFieldLinguistics)  A collection of scripts and recipes for linguistics
+* [translitit-engine ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/translitit-engine.svg)](https://github.com/OpenSourceFieldlinguistics/translitit-engine)  A transliteration engine written in JavaScript
+* [Tsammalex data ![GitHub stars](https://img.shields.io/github/stars/clld/tsammalex-data.svg)](https://github.com/clld/tsammalex-data)  [Tsammalex](http://tsammalex.clld.org) is a multilingual lexical database on plants and animals. The data published on the Tsammalex website is curated collaboratively at https://github.com/clld/tsammalex-data
+* [tweet2learn ![GitHub stars](https://img.shields.io/github/stars/kscanne/tweet2learn.svg)](https://github.com/kscanne/tweet2learn)  An app to make it easier to use your native language on Twitter
 * [Unicodify](http://www.lancaster.ac.uk/staff/hardiea/unicodify.htm) Unicodify is a suite of programs for converting text in a variety of 8-bit encodings to Unicode (using the UTF-16 encoding). Unicodify was particularly designed to handle HTML-based text using non-ISCII 8-bit fonts to render South Asian scripts. However, elements of the suite can map other types of non-ASCII 8-bit encodings, such as Latin-2, ISCII and PASCII.
-* [UniversalDependencies docs](https://github.com/UniversalDependencies/docs) Universal Dependencies online documentation http://universaldependencies.github.io/docs/
-* [UniversalDependencies tools](https://github.com/universaldependencies/tools) Various utilities for processing the data.
-* [wavesurfer.js](https://github.com/katspaugh/wavesurfer.js) Navigable waveform built on Web Audio and Canvas http://www.wavesurfer.fm (Also has an ELAN plugin)
-* [WeSay](https://github.com/sillsdev/wesay) Allows language communities to build their own dictionaries. http://wesay.org (by the SIL International)
-* [WordBoundary](https://github.com/eddersko/WordBoundary) An experiment in the detection and segmentation of word boundaries
-* [wordbyword](https://github.com/cidles/wordbyword) WordByWord is a free, open source, easy-to-use multimedia vocabulary trainer developed by Vera Ferreira, Peter Bouda, and Ricardo Filipe at CIDLeS with the support of the Foundation for Endangered Languages.
-* [WSI4URLang](https://github.com/mohammadnasiruddin/WSI4URLang) Word Sense Induction (WSI) for Under-resourced Languages (URLang) http://www.mohammadnasiruddin.eu/under-resourced-language-urlang.html
-* [XDXF_Makedict](https://github.com/soshial/xdxf_makedict) XDXF dictionary format and "makedict" dictionary converting software (official repository)
+* [UniversalDependencies docs ![GitHub stars](https://img.shields.io/github/stars/UniversalDependencies/docs.svg)](https://github.com/UniversalDependencies/docs)  Universal Dependencies online documentation http://universaldependencies.github.io/docs/
+* [UniversalDependencies tools ![GitHub stars](https://img.shields.io/github/stars/universaldependencies/tools.svg)](https://github.com/universaldependencies/tools)  Various utilities for processing the data.
+* [wavesurfer.js ![GitHub stars](https://img.shields.io/github/stars/katspaugh/wavesurfer.js.svg)](https://github.com/katspaugh/wavesurfer.js)  Navigable waveform built on Web Audio and Canvas http://www.wavesurfer.fm (Also has an ELAN plugin)
+* [WeSay ![GitHub stars](https://img.shields.io/github/stars/sillsdev/wesay.svg)](https://github.com/sillsdev/wesay)  Allows language communities to build their own dictionaries. http://wesay.org (by the SIL International)
+* [WordBoundary ![GitHub stars](https://img.shields.io/github/stars/eddersko/WordBoundary.svg)](https://github.com/eddersko/WordBoundary)  An experiment in the detection and segmentation of word boundaries
+* [wordbyword ![GitHub stars](https://img.shields.io/github/stars/cidles/wordbyword.svg)](https://github.com/cidles/wordbyword)  WordByWord is a free, open source, easy-to-use multimedia vocabulary trainer developed by Vera Ferreira, Peter Bouda, and Ricardo Filipe at CIDLeS with the support of the Foundation for Endangered Languages.
+* [WSI4URLang ![GitHub stars](https://img.shields.io/github/stars/mohammadnasiruddin/WSI4URLang.svg)](https://github.com/mohammadnasiruddin/WSI4URLang)  Word Sense Induction (WSI) for Under-resourced Languages (URLang) http://www.mohammadnasiruddin.eu/under-resourced-language-urlang.html
+* [XDXF_Makedict ![GitHub stars](https://img.shields.io/github/stars/soshial/xdxf_makedict.svg)](https://github.com/soshial/xdxf_makedict)  XDXF dictionary format and "makedict" dictionary converting software (official repository)
 * [XTrans](https://www.ldc.upenn.edu/language-resources/tools/xtrans) Trans is a next generation multi-platform, multilingual, multi-channel transcription tool that supports manual transcription and annotation of audio recordings. The XTrans toolkit provides new and efficient solutions to common transcription challenges and addresses critical gaps in existing tools.Designed with input from experienced human transcribers working with real world data, XTrans provides a flexible and intuitive graphical user interface for a multitude of speech annotation tasks including (virtual) segmentation of audio into smaller units like turns and sentences; speaker identification; orthographic transcription in any language; and labeling of structural elements of the transcript like topics.
 
 # i18n-related Repositories
@@ -216,45 +216,45 @@ Looking for resources for code languages? Take a look at [the awesome collection
 
 # Audio automation
 
-* [arctic-prompts](https://github.com/psibre/arctic-prompts) Generate prompts PDF for CMU ARCTIC dataset
-* [AudioWebService](https://github.com/OpenSourceFieldlinguistics/AudioWebService) a simple nodejs server which accepts upload of audio and runs it through praat
-* [AuToBI](https://github.com/AndrewRosenberg/AuToBI) Automatic prosodic annotation tool written in Java.
-* [BashScriptsForPhonetics](https://github.com/OpenSourceFieldlinguistics/BashScriptsForPhonetics)  (_Fork_ of a dormant project)
-* [esv-text-audio-aligner](https://github.com/westonruter/esv-text-audio-aligner) ESV Text/Audio Aligner to programmatically obtain the timings for each word in the corresponding audio
-* [et-pocketsphinx-tutorial](https://github.com/OpenSourceFieldlinguistics/et-pocketsphinx-tutorial) Tutorial of Estonian speech recognition using PocketSphinx
-* [html5-audio-read-along](https://github.com/westonruter/html5-audio-read-along) HTML5 Audio Read-Along
-* [ipa-chart](https://github.com/westonruter/ipa-chart) International Phonetic Alphabet (IPA) Unicode Chart and Character Picker
-* [lex4all](https://github.com/OpenSourceFieldlinguistics/lex4all) pronunciation LEXicons for Any Low-resource Language (_Fork_ of a student project)
-* [opensauce](https://github.com/voicesauce/opensauce) GNU Octave-compatible version of VoiceSauce
-* [pocketsphinx.js](https://github.com/syl22-00/pocketsphinx.js) Speech recognition in JavaScript
-* [praat-py](https://github.com/OpenSourceFieldlinguistics/praat-py) From my PhD days: Praat-Py is a custom build of Praat, the computer program used by linguists for doing phonetic analysis on sound files, to allow for scripts to be written in the Python programming language, rather than in Praat's built-in language. (_Fork_ of a dormant project)
-* [Praat-Scripts](https://github.com/OpenSourceFieldlinguistics/Praat-Scripts) Mietta's Scripts
-* [PraatTextGridJS](https://github.com/OpenSourceFieldlinguistics/PraatTextGridJS) A small library which can parse TextGrid into json and json into TextGrid
-* [prosodicParsing](https://github.com/jpate/prosodicParsing) different kinds of HMMs to use for incorporating prosody into basic parsing
-* [Prosodylab-Aligner](https://github.com/prosodylab/Prosodylab-Aligner) Python interface for forced audio alignment using HTK and SoX
-* [prosodylab.alignertools](https://github.com/prosodylab/prosodylab.alignertools)
-* [Recordmp3js](https://github.com/OpenSourceFieldlinguistics/Recordmp3js) Record MP3 files directly from the browser using JS and HTML
+* [arctic-prompts ![GitHub stars](https://img.shields.io/github/stars/psibre/arctic-prompts.svg)](https://github.com/psibre/arctic-prompts)  Generate prompts PDF for CMU ARCTIC dataset
+* [AudioWebService ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/AudioWebService.svg)](https://github.com/OpenSourceFieldlinguistics/AudioWebService)  a simple nodejs server which accepts upload of audio and runs it through praat
+* [AuToBI ![GitHub stars](https://img.shields.io/github/stars/AndrewRosenberg/AuToBI.svg)](https://github.com/AndrewRosenberg/AuToBI)  Automatic prosodic annotation tool written in Java.
+* [BashScriptsForPhonetics ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/BashScriptsForPhonetics.svg)](https://github.com/OpenSourceFieldlinguistics/BashScriptsForPhonetics)   (_Fork_ of a dormant project)
+* [esv-text-audio-aligner ![GitHub stars](https://img.shields.io/github/stars/westonruter/esv-text-audio-aligner.svg)](https://github.com/westonruter/esv-text-audio-aligner)  ESV Text/Audio Aligner to programmatically obtain the timings for each word in the corresponding audio
+* [et-pocketsphinx-tutorial ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/et-pocketsphinx-tutorial.svg)](https://github.com/OpenSourceFieldlinguistics/et-pocketsphinx-tutorial)  Tutorial of Estonian speech recognition using PocketSphinx
+* [html5-audio-read-along ![GitHub stars](https://img.shields.io/github/stars/westonruter/html5-audio-read-along.svg)](https://github.com/westonruter/html5-audio-read-along)  HTML5 Audio Read-Along
+* [ipa-chart ![GitHub stars](https://img.shields.io/github/stars/westonruter/ipa-chart.svg)](https://github.com/westonruter/ipa-chart)  International Phonetic Alphabet (IPA) Unicode Chart and Character Picker
+* [lex4all ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/lex4all.svg)](https://github.com/OpenSourceFieldlinguistics/lex4all)  pronunciation LEXicons for Any Low-resource Language (_Fork_ of a student project)
+* [opensauce ![GitHub stars](https://img.shields.io/github/stars/voicesauce/opensauce.svg)](https://github.com/voicesauce/opensauce)  GNU Octave-compatible version of VoiceSauce
+* [pocketsphinx.js ![GitHub stars](https://img.shields.io/github/stars/syl22-00/pocketsphinx.js.svg)](https://github.com/syl22-00/pocketsphinx.js)  Speech recognition in JavaScript
+* [praat-py ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/praat-py.svg)](https://github.com/OpenSourceFieldlinguistics/praat-py)  From my PhD days: Praat-Py is a custom build of Praat, the computer program used by linguists for doing phonetic analysis on sound files, to allow for scripts to be written in the Python programming language, rather than in Praat's built-in language. (_Fork_ of a dormant project)
+* [Praat-Scripts ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/Praat-Scripts.svg)](https://github.com/OpenSourceFieldlinguistics/Praat-Scripts)  Mietta's Scripts
+* [PraatTextGridJS ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/PraatTextGridJS.svg)](https://github.com/OpenSourceFieldlinguistics/PraatTextGridJS)  A small library which can parse TextGrid into json and json into TextGrid
+* [prosodicParsing ![GitHub stars](https://img.shields.io/github/stars/jpate/prosodicParsing.svg)](https://github.com/jpate/prosodicParsing)  different kinds of HMMs to use for incorporating prosody into basic parsing
+* [Prosodylab-Aligner ![GitHub stars](https://img.shields.io/github/stars/prosodylab/Prosodylab-Aligner.svg)](https://github.com/prosodylab/Prosodylab-Aligner)  Python interface for forced audio alignment using HTK and SoX
+* [prosodylab.alignertools ![GitHub stars](https://img.shields.io/github/stars/prosodylab/prosodylab.alignertools.svg)](https://github.com/prosodylab/prosodylab.alignertools) 
+* [Recordmp3js ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/Recordmp3js.svg)](https://github.com/OpenSourceFieldlinguistics/Recordmp3js)  Record MP3 files directly from the browser using JS and HTML
 
 # Text automation
 
-* [clld](https://github.com/clld/clld) Cross Linguistic Linked Data python library
-* [LaTeX2HTML5](https://github.com/pyramation/LaTeX2HTML5) LaTeX web components
-* [MultilingualCorporaExtractor](https://github.com/OpenSourceFieldlinguistics/MultilingualCorporaExtractor) Node io Spider for extracting multilingual corpora (_Fork_ of a student project)
-* [SeedLing](https://github.com/OpenSourceFieldlinguistics/SeedLing) Building and Using A Seed Corpus for the Human Language Project (_Fork_ of a student project)
+* [clld ![GitHub stars](https://img.shields.io/github/stars/clld/clld.svg)](https://github.com/clld/clld)  Cross Linguistic Linked Data python library
+* [LaTeX2HTML5 ![GitHub stars](https://img.shields.io/github/stars/pyramation/LaTeX2HTML5.svg)](https://github.com/pyramation/LaTeX2HTML5)  LaTeX web components
+* [MultilingualCorporaExtractor ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/MultilingualCorporaExtractor.svg)](https://github.com/OpenSourceFieldlinguistics/MultilingualCorporaExtractor)  Node io Spider for extracting multilingual corpora (_Fork_ of a student project)
+* [SeedLing ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/SeedLing.svg)](https://github.com/OpenSourceFieldlinguistics/SeedLing)  Building and Using A Seed Corpus for the Human Language Project (_Fork_ of a student project)
 
 # Experimentation
 
-* [experigen](https://github.com/tlozoot/experigen) A framework for creating linguistic experiments
-* [GamifyPsycholinguisticsExperiments](https://github.com/OpenSourceFieldlinguistics/GamifyPsycholinguisticsExperiments) A simple node server to gamify linguistics experiments, runs offline on a laptop for small scale experiements and online on a server for large scale experiments. Data is sent to a Google spreadsheet. (_Fork_ of a dormant project)
-* [OpenSesame](https://github.com/smathot/OpenSesame) Graphical experiment builder for the social sciences
-* [OPrime](https://github.com/OpenSourceFieldlinguistics/OPrime) Open Source Experimentation Libraries - Online and Offline for Android and HTML5
-* [psychopyMegProsody](https://github.com/OpenSourceFieldlinguistics/psychopyMegProsody) Runs MegProsody using PsychoPy.
-* [PsychScript](https://github.com/EoinTravers/PsychScript) A HTML5/Javascript library for running behavioural experiments online.
+* [experigen ![GitHub stars](https://img.shields.io/github/stars/tlozoot/experigen.svg)](https://github.com/tlozoot/experigen)  A framework for creating linguistic experiments
+* [GamifyPsycholinguisticsExperiments ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/GamifyPsycholinguisticsExperiments.svg)](https://github.com/OpenSourceFieldlinguistics/GamifyPsycholinguisticsExperiments)  A simple node server to gamify linguistics experiments, runs offline on a laptop for small scale experiements and online on a server for large scale experiments. Data is sent to a Google spreadsheet. (_Fork_ of a dormant project)
+* [OpenSesame ![GitHub stars](https://img.shields.io/github/stars/smathot/OpenSesame.svg)](https://github.com/smathot/OpenSesame)  Graphical experiment builder for the social sciences
+* [OPrime ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/OPrime.svg)](https://github.com/OpenSourceFieldlinguistics/OPrime)  Open Source Experimentation Libraries - Online and Offline for Android and HTML5
+* [psychopyMegProsody ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/psychopyMegProsody.svg)](https://github.com/OpenSourceFieldlinguistics/psychopyMegProsody)  Runs MegProsody using PsychoPy.
+* [PsychScript ![GitHub stars](https://img.shields.io/github/stars/EoinTravers/PsychScript.svg)](https://github.com/EoinTravers/PsychScript)  A HTML5/Javascript library for running behavioural experiments online.
 
 
 # Natural language generation
 
-* [hailo](https://github.com/OpenSourceFieldlinguistics/hailo) A conversation bot using Markov chains
+* [hailo ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/hailo.svg)](https://github.com/OpenSourceFieldlinguistics/hailo)  A conversation bot using Markov chains
 
 # Computing systems
 
@@ -262,82 +262,82 @@ Looking for resources for code languages? Take a look at [the awesome collection
 
 # Android Applications
 
-* [Aikuma](https://github.com/langtech/aikuma) Android software for recording and translation http://lp20.org/aikuma
-* [AndroidFieldDB](https://github.com/OpenSourceFieldlinguistics/AndroidFieldDB) An Android app which lets the user build a custom visual and auditory vocabulary, useful for guided anomia treatment and self designed language lessons by heritage speakers.
-* [AndroidFieldDBElicitationRecorder](https://github.com/OpenSourceFieldlinguistics/AndroidFieldDBElicitationRecorder) A general purpose video recording tool
-* [AndroidLanguageLearningClientForFieldDB](https://github.com/OpenSourceFieldlinguistics/AndroidLanguageLearningClientForFieldDB) An Android language learning app which plugs into a FieldDB corpus to create language learning apps.
-* [AndroidProductionExperiment](https://github.com/OpenSourceFieldlinguistics/AndroidProductionExperiment) Android App to run perception experiments
-* [Bevara](https://github.com/KentonMurray/bevara) Android Phone Application designed for Linguistic Fieldwork to help preserve, maintain, and save endangered languages
-* [ojoVoz](https://github.com/ojovoz/ojoVoz_mobile) A mobile app for sending georeferenced image and voice recordings from an Adroid phone to an email address. For more information, please go to http://sautiyawakulima.net/ojovoz
+* [Aikuma ![GitHub stars](https://img.shields.io/github/stars/langtech/aikuma.svg)](https://github.com/langtech/aikuma)  Android software for recording and translation http://lp20.org/aikuma
+* [AndroidFieldDB ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/AndroidFieldDB.svg)](https://github.com/OpenSourceFieldlinguistics/AndroidFieldDB)  An Android app which lets the user build a custom visual and auditory vocabulary, useful for guided anomia treatment and self designed language lessons by heritage speakers.
+* [AndroidFieldDBElicitationRecorder ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/AndroidFieldDBElicitationRecorder.svg)](https://github.com/OpenSourceFieldlinguistics/AndroidFieldDBElicitationRecorder)  A general purpose video recording tool
+* [AndroidLanguageLearningClientForFieldDB ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/AndroidLanguageLearningClientForFieldDB.svg)](https://github.com/OpenSourceFieldlinguistics/AndroidLanguageLearningClientForFieldDB)  An Android language learning app which plugs into a FieldDB corpus to create language learning apps.
+* [AndroidProductionExperiment ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/AndroidProductionExperiment.svg)](https://github.com/OpenSourceFieldlinguistics/AndroidProductionExperiment)  Android App to run perception experiments
+* [Bevara ![GitHub stars](https://img.shields.io/github/stars/KentonMurray/bevara.svg)](https://github.com/KentonMurray/bevara)  Android Phone Application designed for Linguistic Fieldwork to help preserve, maintain, and save endangered languages
+* [ojoVoz ![GitHub stars](https://img.shields.io/github/stars/ojovoz/ojoVoz_mobile.svg)](https://github.com/ojovoz/ojoVoz_mobile)  A mobile app for sending georeferenced image and voice recordings from an Adroid phone to an email address. For more information, please go to http://sautiyawakulima.net/ojovoz
 * [Template for Word-Learning App] (https://github.com/eddersko/android-template) This is a template of an Android word-learning app that may be used a way to introduce a language. It includes a quiz. For the documentation, go to http://eddersko.github.io/android-template/
 
 # Chrome Extensions
 
-* [babelfrog](https://github.com/dergachev/babelfrog) Chrome extension to help learn languages as you browse.
-* [DictionaryChromeExtension](https://github.com/OpenSourceFieldlinguistics/DictionaryChromeExtension) Dictionary for websites in low-resource languages. App and codebase which connects to a Wiktionary to provide definitions of any term on any website (current languages Cherokee 194,426 entries, Inuktitut 251 entries, Kartuli 7,363 entries, Plains Cree (incubation) 0 entries) [use](https://chrome.google.com/webstore/detail/my-dictionary/jfmpeiicncingobdejgmmcamknndpbbi)
-* [KartuliChromeExtension](https://github.com/batumi/KartuliChromeExtension) Codebase to turn any webpage from any alphabet into another alphabet, the default is to turn latin letters into Kartuli. [use](https://chrome.google.com/webstore/detail/kartuli-glasses/ccmledaklimnhjchkcgideafpglhejja) "Do your friends keep commenting on Facebook with English keyboards (either because they forgot to switch, or because they didn't/can't install a Georgian keyboard)? Now you can read the web through კართული eyes."
+* [babelfrog ![GitHub stars](https://img.shields.io/github/stars/dergachev/babelfrog.svg)](https://github.com/dergachev/babelfrog)  Chrome extension to help learn languages as you browse.
+* [DictionaryChromeExtension ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/DictionaryChromeExtension.svg)](https://github.com/OpenSourceFieldlinguistics/DictionaryChromeExtension)  Dictionary for websites in low-resource languages. App and codebase which connects to a Wiktionary to provide definitions of any term on any website (current languages Cherokee 194,426 entries, Inuktitut 251 entries, Kartuli 7,363 entries, Plains Cree (incubation) 0 entries) [use](https://chrome.google.com/webstore/detail/my-dictionary/jfmpeiicncingobdejgmmcamknndpbbi)
+* [KartuliChromeExtension ![GitHub stars](https://img.shields.io/github/stars/batumi/KartuliChromeExtension.svg)](https://github.com/batumi/KartuliChromeExtension)  Codebase to turn any webpage from any alphabet into another alphabet, the default is to turn latin letters into Kartuli. [use](https://chrome.google.com/webstore/detail/kartuli-glasses/ccmledaklimnhjchkcgideafpglhejja) "Do your friends keep commenting on Facebook with English keyboards (either because they forgot to switch, or because they didn't/can't install a Georgian keyboard)? Now you can read the web through კართული eyes."
 
 # FieldDB
 
 _FieldDB_ is actively worked on by the [https://github.com/OpenSourceFieldlinguistics] group. These repos explicitly work with it but could be repurposed for other projects.
 
-* [FieldDB](https://github.com/OpenSourceFieldlinguistics/FieldDB) An offline/online field database which adapts to its user's terminology and I-Language, has plugins for various data automation routines along the process of primary data collection to cleaning to publication and archival. [use](https://wwwdev.lingsync.org/)
+* [FieldDB ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/FieldDB.svg)](https://github.com/OpenSourceFieldlinguistics/FieldDB)  An offline/online field database which adapts to its user's terminology and I-Language, has plugins for various data automation routines along the process of primary data collection to cleaning to publication and archival. [use](https://wwwdev.lingsync.org/)
 
 ## FieldDB Webservices/Components/Plugins
 
-* [AndroidLanguageLearningClientForFieldDB-sikuli](https://github.com/OpenSourceFieldlinguistics/AndroidLanguageLearningClientForFieldDB-sikuli) Sikuli tests for AndroidLanguageLearningClientForFieldDB
-* [AuthenticationWebService](https://github.com/OpenSourceFieldlinguistics/AuthenticationWebService) A node.js web service which mananges users and corpora creation and authentication [use](https://api.lingsync.org/)
-* [bower-fielddb-angular](https://github.com/OpenSourceFieldlinguistics/bower-fielddb-angular) A bower repository which hosts fielddb-angular components, bower install fielddb-angular --save
-* [bower-fielddb](https://github.com/OpenSourceFieldlinguistics/bower-fielddb) A bower repository which hosts fielddb core components, bower install fielddb --save
-* [dative](https://github.com/OpenSourceFieldlinguistics/dative) A single-page application that interacts with multiple linguistic fieldwork web service databases. [use](https://dative.lingsync.org/)
-* [fielddb-spreadsheet-sikuli](https://github.com/OpenSourceFieldlinguistics/fielddb-spreadsheet-sikuli) sikuli tests for the spreadsheet module [use](https://www.youtube.com/watch?v=pPN8e1m6RBU&feature=youtu.be)
-* [FieldDBActivityFeed](https://github.com/OpenSourceFieldlinguistics/FieldDBActivityFeed) A fielddb activity feed widget which can be embedded in other codebases, websites etc [use](https://chrome.google.com/webstore/detail/lingsync-prototype/eeipnabdeimobhlkfaiohienhibfcfpa)
-* [FieldDBGlosser](https://github.com/OpenSourceFieldlinguistics/FieldDBGlosser) A semi-unsupervised language independent morphological analyzer useful for stemming unknown language text, or getting a rough estimate of possible parses for morphemes in a word. bower install fielddb-glosser --save
-* [FieldDBLexicon](https://github.com/OpenSourceFieldlinguistics/FieldDBLexicon) A lexicon browser/editor web widget for FieldDB databases [use](https://lexicondev.lingsync.org/)
-* [FieldDBWebServer](https://github.com/OpenSourceFieldlinguistics/FieldDBWebServer) Web server which can display FieldDB public corpora/user's share pages [use](https://wwwdev.lingsync.org/lingllama/communitycorpus/lingllama-communitycorpus)
-* [LanguageClassDashboard](https://github.com/OpenSourceFieldlinguistics/LanguageClassDashboard) App which provides a view of FieldDB corpora for language teachers [use](http://app.phophlo.ca/)
-* [LexiconWebService](https://github.com/OpenSourceFieldlinguistics/LexiconWebService) A node.js ElasticSearch wrapper for indexing/training  lexicons from corpora [use](https://wwwdev.lingsync.org/lingllama/communitycorpus/lingllama-communitycorpus)
-* [LexiconWebServiceSample](https://github.com/OpenSourceFieldlinguistics/LexiconWebServiceSample) A node.js web server which implements the fieldlinguist's lexicon API for the FieldDB project. [use](https://lexicondev.lingsync.org/analysisbytierbyword/inuktitut/nunaqjuaqli%20aaqkiksimalaunngilaq%20sunataqaranilu%20itijuqjuamik%20taaqtualuulluni%20guutiullu%20anirngninga%20ingirralauqpuq%20imaaluup%20qulaagut)
+* [AndroidLanguageLearningClientForFieldDB-sikuli ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/AndroidLanguageLearningClientForFieldDB-sikuli.svg)](https://github.com/OpenSourceFieldlinguistics/AndroidLanguageLearningClientForFieldDB-sikuli)  Sikuli tests for AndroidLanguageLearningClientForFieldDB
+* [AuthenticationWebService ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/AuthenticationWebService.svg)](https://github.com/OpenSourceFieldlinguistics/AuthenticationWebService)  A node.js web service which mananges users and corpora creation and authentication [use](https://api.lingsync.org/)
+* [bower-fielddb-angular ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/bower-fielddb-angular.svg)](https://github.com/OpenSourceFieldlinguistics/bower-fielddb-angular)  A bower repository which hosts fielddb-angular components, bower install fielddb-angular --save
+* [bower-fielddb ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/bower-fielddb.svg)](https://github.com/OpenSourceFieldlinguistics/bower-fielddb)  A bower repository which hosts fielddb core components, bower install fielddb --save
+* [dative ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/dative.svg)](https://github.com/OpenSourceFieldlinguistics/dative)  A single-page application that interacts with multiple linguistic fieldwork web service databases. [use](https://dative.lingsync.org/)
+* [fielddb-spreadsheet-sikuli ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/fielddb-spreadsheet-sikuli.svg)](https://github.com/OpenSourceFieldlinguistics/fielddb-spreadsheet-sikuli)  sikuli tests for the spreadsheet module [use](https://www.youtube.com/watch?v=pPN8e1m6RBU&feature=youtu.be)
+* [FieldDBActivityFeed ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/FieldDBActivityFeed.svg)](https://github.com/OpenSourceFieldlinguistics/FieldDBActivityFeed)  A fielddb activity feed widget which can be embedded in other codebases, websites etc [use](https://chrome.google.com/webstore/detail/lingsync-prototype/eeipnabdeimobhlkfaiohienhibfcfpa)
+* [FieldDBGlosser ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/FieldDBGlosser.svg)](https://github.com/OpenSourceFieldlinguistics/FieldDBGlosser)  A semi-unsupervised language independent morphological analyzer useful for stemming unknown language text, or getting a rough estimate of possible parses for morphemes in a word. bower install fielddb-glosser --save
+* [FieldDBLexicon ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/FieldDBLexicon.svg)](https://github.com/OpenSourceFieldlinguistics/FieldDBLexicon)  A lexicon browser/editor web widget for FieldDB databases [use](https://lexicondev.lingsync.org/)
+* [FieldDBWebServer ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/FieldDBWebServer.svg)](https://github.com/OpenSourceFieldlinguistics/FieldDBWebServer)  Web server which can display FieldDB public corpora/user's share pages [use](https://wwwdev.lingsync.org/lingllama/communitycorpus/lingllama-communitycorpus)
+* [LanguageClassDashboard ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/LanguageClassDashboard.svg)](https://github.com/OpenSourceFieldlinguistics/LanguageClassDashboard)  App which provides a view of FieldDB corpora for language teachers [use](http://app.phophlo.ca/)
+* [LexiconWebService ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/LexiconWebService.svg)](https://github.com/OpenSourceFieldlinguistics/LexiconWebService)  A node.js ElasticSearch wrapper for indexing/training  lexicons from corpora [use](https://wwwdev.lingsync.org/lingllama/communitycorpus/lingllama-communitycorpus)
+* [LexiconWebServiceSample ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/LexiconWebServiceSample.svg)](https://github.com/OpenSourceFieldlinguistics/LexiconWebServiceSample)  A node.js web server which implements the fieldlinguist's lexicon API for the FieldDB project. [use](https://lexicondev.lingsync.org/analysisbytierbyword/inuktitut/nunaqjuaqli%20aaqkiksimalaunngilaq%20sunataqaranilu%20itijuqjuamik%20taaqtualuulluni%20guutiullu%20anirngninga%20ingirralauqpuq%20imaaluup%20qulaagut)
 
 
 # Academic Research Paper-Specific Repositories
 
 * [Gargantua](http://sourceforge.net/projects/gargantua/) Fast Unsupervised Sentence Aligner described in "Improved unsupervised sentence alignment for symmetrical and asymmetrical parallel corpora", COLING 2010.
-* [ldc-kiy](https://github.com/krismyu/ldc-kiy) Materials for: The experimental state of mind in elicitation: illustrations from tonal fieldwork. Dubmitted to Language Documentation & Conservation, _How to study a tone language_.
+* [ldc-kiy ![GitHub stars](https://img.shields.io/github/stars/krismyu/ldc-kiy.svg)](https://github.com/krismyu/ldc-kiy)  Materials for: The experimental state of mind in elicitation: illustrations from tonal fieldwork. Dubmitted to Language Documentation & Conservation, _How to study a tone language_.
 * [Learning to map into a Univerisal POS tagset](http://groups.csail.mit.edu/rbg/code/unitag/)  Yuan Zhang, Roi Reichart, Regina Barzilay and Amir Globerson
-* [low-resource-pos-tagging-2013](https://github.com/dhgarrette/low-resource-pos-tagging-2013) and [low-resource-pos-tagging-2013](https://github.com/dhgarrette/low-resource-pos-tagging-2014) Published in: Learning a Part-of-Speech Tagger from Two Hours of Annotation. _Dan Garrette and Jason Baldridge_. In Proceedings of NAACL 2013. And in: Real-World Semi-Supervised Learning of POS-Taggers for Low-Resource Languages. _Dan Garrette, Jason Mielens, and Jason Baldridge_. In Proceedings of ACL 2013.
-* [orthotree](https://github.com/kscanne/orthotree) Linguistic family tree based on orthographic distance
-* [type-supervised-tagging-2012emnlp](https://github.com/dhgarrette/type-supervised-tagging-2012emnlp) This repository contains the code, scripts, and instructions needed to reproduce the results in the paper: Type-Supervised Hidden Markov Models for Part-of-Speech Tagging with Incomplete Tag Dictionaries. _Dan Garrette and Jason Baldridge_. In Proceedings of EMNLP 2012. This code is frozen as of the version used to obtain the results in the paper. It will not be maintained. To see the updated code, visit [nlp](https://github.com/dhgarrette/nlp)
-* [visualizing-language](https://github.com/RichardLitt/visualizing-language) For visualizations of WALS and other typological databases
-* [WALS-APiCS](https://github.com/jcgood/complexity) Code for working with WALS-APiCS (Atlas of Pidgin and Creole Language Structures) complexity metrics
+* [low-resource-pos-tagging-2013 ![GitHub stars](https://img.shields.io/github/stars/dhgarrette/low-resource-pos-tagging-2013.svg)](https://github.com/dhgarrette/low-resource-pos-tagging-2013)  and [low-resource-pos-tagging-2013](https://github.com/dhgarrette/low-resource-pos-tagging-2014) Published in: Learning a Part-of-Speech Tagger from Two Hours of Annotation. _Dan Garrette and Jason Baldridge_. In Proceedings of NAACL 2013. And in: Real-World Semi-Supervised Learning of POS-Taggers for Low-Resource Languages. _Dan Garrette, Jason Mielens, and Jason Baldridge_. In Proceedings of ACL 2013.
+* [orthotree ![GitHub stars](https://img.shields.io/github/stars/kscanne/orthotree.svg)](https://github.com/kscanne/orthotree)  Linguistic family tree based on orthographic distance
+* [type-supervised-tagging-2012emnlp ![GitHub stars](https://img.shields.io/github/stars/dhgarrette/type-supervised-tagging-2012emnlp.svg)](https://github.com/dhgarrette/type-supervised-tagging-2012emnlp)  This repository contains the code, scripts, and instructions needed to reproduce the results in the paper: Type-Supervised Hidden Markov Models for Part-of-Speech Tagging with Incomplete Tag Dictionaries. _Dan Garrette and Jason Baldridge_. In Proceedings of EMNLP 2012. This code is frozen as of the version used to obtain the results in the paper. It will not be maintained. To see the updated code, visit [nlp](https://github.com/dhgarrette/nlp)
+* [visualizing-language ![GitHub stars](https://img.shields.io/github/stars/RichardLitt/visualizing-language.svg)](https://github.com/RichardLitt/visualizing-language)  For visualizations of WALS and other typological databases
+* [WALS-APiCS ![GitHub stars](https://img.shields.io/github/stars/jcgood/complexity.svg)](https://github.com/jcgood/complexity)  Code for working with WALS-APiCS (Atlas of Pidgin and Creole Language Structures) complexity metrics
 
 # Example Repositories
 
 _These are repositories that are generally only interesting for training purposes or seeing how something is done._
 
-* [CorpusWebService](https://github.com/OpenSourceFieldlinguistics/CorpusWebService) über-simple node.js-Proxy to enable CORS request for couchdb
-* [CorporaForFieldLinguistics](https://github.com/OpenSourceFieldlinguistics/CorporaForFieldLinguistics)
-* [startR](https://github.com/OpenSourceFieldlinguistics/startR)
-* [lucenerevolution-2013](https://github.com/OpenSourceFieldlinguistics/lucenerevolution-2013) Demo examples for linguistics in Lucene and Solr
-* [berlin-buzzwords-2013](https://github.com/OpenSourceFieldlinguistics/berlin-buzzwords-2013) Demo examples for Lucene, Solr, ElasticSearch and OpenNLP from Berlin Buzzwords 2013 talk
+* [CorpusWebService ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/CorpusWebService.svg)](https://github.com/OpenSourceFieldlinguistics/CorpusWebService)  über-simple node.js-Proxy to enable CORS request for couchdb
+* [CorporaForFieldLinguistics ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/CorporaForFieldLinguistics.svg)](https://github.com/OpenSourceFieldlinguistics/CorporaForFieldLinguistics) 
+* [startR ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/startR.svg)](https://github.com/OpenSourceFieldlinguistics/startR) 
+* [lucenerevolution-2013 ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/lucenerevolution-2013.svg)](https://github.com/OpenSourceFieldlinguistics/lucenerevolution-2013)  Demo examples for linguistics in Lucene and Solr
+* [berlin-buzzwords-2013 ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/berlin-buzzwords-2013.svg)](https://github.com/OpenSourceFieldlinguistics/berlin-buzzwords-2013)  Demo examples for Lucene, Solr, ElasticSearch and OpenNLP from Berlin Buzzwords 2013 talk
 
 # Language & Code Interfaces
 
-* [قلب](https://github.com/nasser/---)‬ is a simple, Scheme-like programming language that you code entirely in Arabic. It is an exploration of the impact of human culture on computer science, the role of tradition in software engineering, and the connection between natural and computer languages.
+* [قلب ![GitHub stars](https://img.shields.io/github/stars/nasser/---.svg)](https://github.com/nasser/---) ‬ is a simple, Scheme-like programming language that you code entirely in Arabic. It is an exploration of the impact of human culture on computer science, the role of tradition in software engineering, and the connection between natural and computer languages.
 
 # Organisations
 
 ## On GitHub
 
-* [batumi](https://github.com/batumi) Speech recognition and natural language processing for low-resource languages
-* [lex4all](https://github.com/lex4all)
-* [longnow](https://github.com/longnow)
-* [NLTK](https://github.com/nltk/nltk) [http://nltk.github.com/](http://nltk.github.com/)
-* [OpenSourceFieldLinguistics](https://github.com/OpenSourceFieldlinguistics)
-* [PhonologicalCorpusTools](https://github.com/PhonologicalCorpusTools)
-* [Projet de recherche sur l'écriture](https://github.com/projetDeRechercheSurLecriture/) crowdsourcing or conducting large scale psycholinguistics experiments (or statistically significant field linguistics)
-* [SIL International](https://github.com/sillsdev) [SIL International](http://www.sil.org/) SIL (originally known as the Summer Institute of Linguistics, Inc.) is probably the leading organization which provides software and tools tailored for use by field linguists and lexicographers working on endangered languages. A little known fact is that much of it's code is open sourced on GitHub and SIL is happy to recieve open source contributions and collaborate on open source projects.
-* [SIL NRSI](https://github.com/silnrsi) SIL Non-Roman Script Initiative. The NRSI is a department of  SIL International, whose task is to provide assistance, research and development for SIL International and its partners to support the use of non-Roman and complex scripts in language development.
+* [batumi ![GitHub stars](https://img.shields.io/github/stars/batumi/AndroidSpeechRecognitionTrainer.svg)](https://github.com/batumi)  Speech recognition and natural language processing for low-resource languages
+* [lex4all ![GitHub stars](https://img.shields.io/github/stars/lex4all/lex4all.svg)](https://github.com/lex4all) 
+* [longnow ![GitHub stars](https://img.shields.io/github/stars/longnow/longview.svg)](https://github.com/longnow) 
+* [NLTK ![GitHub stars](https://img.shields.io/github/stars/nltk/nltk.svg)](https://github.com/nltk/nltk)  [http://nltk.github.com/](http://nltk.github.com/)
+* [OpenSourceFieldLinguistics ![GitHub stars](https://img.shields.io/github/stars/fielddb/fielddb.svg)](https://github.com/OpenSourceFieldlinguistics) 
+* [PhonologicalCorpusTools ![GitHub stars](https://img.shields.io/github/stars/PhonologicalCorpusTools/CorpusTools.svg)](https://github.com/PhonologicalCorpusTools) 
+* [Projet de recherche sur l'écriture ![GitHub stars](https://img.shields.io/github/stars/projetDeRechercheSurLecriture/DyslexDisorthGame.svg)](https://github.com/projetDeRechercheSurLecriture/)  crowdsourcing or conducting large scale psycholinguistics experiments (or statistically significant field linguistics)
+* [SIL International ![GitHub stars](https://img.shields.io/github/stars/sillsdev/FieldWorks.svg)](https://github.com/sillsdev)  [SIL International](http://www.sil.org/) SIL (originally known as the Summer Institute of Linguistics, Inc.) is probably the leading organization which provides software and tools tailored for use by field linguists and lexicographers working on endangered languages. A little known fact is that much of it's code is open sourced on GitHub and SIL is happy to recieve open source contributions and collaborate on open source projects.
+* [SIL NRSI ![GitHub stars](https://img.shields.io/github/stars/silnrsi/pysilfont.svg)](https://github.com/silnrsi)  SIL Non-Roman Script Initiative. The NRSI is a department of  SIL International, whose task is to provide assistance, research and development for SIL International and its partners to support the use of non-Roman and complex scripts in language development.
 
 ## Other OSS Organisations
 
@@ -349,7 +349,7 @@ _These are repositories that are generally only interesting for training purpose
 
 _amh :: አማርኛ_
 
-* [HornMorpho](https://github.com/LowResourceLanguages/hltdi-morphology) -
+* [HornMorpho ![GitHub stars](https://img.shields.io/github/stars/LowResourceLanguages/hltdi-morphology.svg)](https://github.com/LowResourceLanguages/hltdi-morphology)  -
 morphological analysis and generation of Amharic and Oromo verbs and nouns and Tigrinya verbs
 
 
@@ -357,7 +357,7 @@ morphological analysis and generation of Amharic and Oromo verbs and nouns and T
 
 _ara :: العربية_
 
-* [Buckwalter](https://github.com/KentonMurray/Buckwalter) A small python script that transliterates Arabic text using the Buckwalter Transliteration Scheme. It allows for multiple decisions to be made around whether or not to include all types of diacritics and characters or ignore them. Useful for NLP experiments where you may want to normalize text.
+* [Buckwalter ![GitHub stars](https://img.shields.io/github/stars/KentonMurray/Buckwalter.svg)](https://github.com/KentonMurray/Buckwalter)  A small python script that transliterates Arabic text using the Buckwalter Transliteration Scheme. It allows for multiple decisions to be made around whether or not to include all types of diacritics and characters or ignore them. Useful for NLP experiments where you may want to normalize text.
 
 ###Bengali
 
@@ -372,62 +372,62 @@ _ben :: বাংলা_
 
 _nya :: chicheŵa_
 
-* [Chichewa](https://github.com/kscanne/chichewa) NLP resources for Chichewa
+* [Chichewa ![GitHub stars](https://img.shields.io/github/stars/kscanne/chichewa.svg)](https://github.com/kscanne/chichewa)  NLP resources for Chichewa
 
 ###Georgian
 
 _kat :: ქართული_
 
-* [translitit-latin-to-mkhedruli-georgian](https://github.com/OpenSourceFieldlinguistics/translitit-latin-to-mkhedruli-georgian) A Latin to ქართული (Mkhedruli Georgian) transliteration function written in JavaScript
+* [translitit-latin-to-mkhedruli-georgian ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/translitit-latin-to-mkhedruli-georgian.svg)](https://github.com/OpenSourceFieldlinguistics/translitit-latin-to-mkhedruli-georgian)  A Latin to ქართული (Mkhedruli Georgian) transliteration function written in JavaScript
 
 ###Guarani
 
 _grn :: Guarani_
 
-* [ParaMorfo](https://github.com/LowResourceLanguages/hltdi-morphology) - morphological analysis and generation of Spanish and Guarani verbs, nouns, and adjectives. Used to be [here](http://www.cs.indiana.edu/~gasser/research/software.html).
+* [ParaMorfo ![GitHub stars](https://img.shields.io/github/stars/LowResourceLanguages/hltdi-morphology.svg)](https://github.com/LowResourceLanguages/hltdi-morphology)  - morphological analysis and generation of Spanish and Guarani verbs, nouns, and adjectives. Used to be [here](http://www.cs.indiana.edu/~gasser/research/software.html).
 
 ###Hindi
 
 _hin :: हिन्दी_
 
-* [hindi-morph](https://github.com/OpenSourceFieldlinguistics/hindi-morph) An open source morphological analyzer for Hindi
+* [hindi-morph ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/hindi-morph.svg)](https://github.com/OpenSourceFieldlinguistics/hindi-morph)  An open source morphological analyzer for Hindi
 
 ###Høgnorsk
 
 _nno :: Høgnorsk_
 
-* [hunspell-hn_NO](https://github.com/rtxanson/hunspell-hn_NO) A beginning to a spellchecking tool for Høgnorsk, a conservative variant of Norwegian Nynorsk, based on a set of corpuses.
+* [hunspell-hn_NO ![GitHub stars](https://img.shields.io/github/stars/rtxanson/hunspell-hn_NO.svg)](https://github.com/rtxanson/hunspell-hn_NO)  A beginning to a spellchecking tool for Høgnorsk, a conservative variant of Norwegian Nynorsk, based on a set of corpuses.
 
 ###Irish
 
 _gle :: Gaeilge_
 
-* [aimsigh](https://github.com/kscanne/aimsigh) Source for the now-defunct aimsigh.com Irish search engine
-* [caighdean](https://github.com/kscanne/caighdean) Code for standardizing Irish language text
-* [fleiscin](https://github.com/kscanne/fleiscin) Irish hyphenation patterns for TeX http://borel.slu.edu/fleiscin/
-* [GaelSpell](https://github.com/kscanne/gaelspell) Sources for an Irish language spell checker
+* [aimsigh ![GitHub stars](https://img.shields.io/github/stars/kscanne/aimsigh.svg)](https://github.com/kscanne/aimsigh)  Source for the now-defunct aimsigh.com Irish search engine
+* [caighdean ![GitHub stars](https://img.shields.io/github/stars/kscanne/caighdean.svg)](https://github.com/kscanne/caighdean)  Code for standardizing Irish language text
+* [fleiscin ![GitHub stars](https://img.shields.io/github/stars/kscanne/fleiscin.svg)](https://github.com/kscanne/fleiscin)  Irish hyphenation patterns for TeX http://borel.slu.edu/fleiscin/
+* [GaelSpell ![GitHub stars](https://img.shields.io/github/stars/kscanne/gaelspell.svg)](https://github.com/kscanne/gaelspell)  Sources for an Irish language spell checker
 * [morphological analyzer & syntactic disambiguator](http://giellatekno.uit.no/doc/lang/gle/IrishDocumentation.html) Elaine Uí Dhonnchadha has produced a morphology in XFST/FOMA, which now seems to be hosted by [Giellatekno]. Includes syntax written in VISL Constraint Grammar.
-* [tesseract-gle-uncial](https://github.com/kscanne/tesseract-gle-uncial/) OCR for old Irish fonts
+* [tesseract-gle-uncial ![GitHub stars](https://img.shields.io/github/stars/kscanne/tesseract-gle-uncial.svg)](https://github.com/kscanne/tesseract-gle-uncial)  OCR for old Irish fonts
 
 ###Japanese
 
 _jpn :: 日本語_
 
-* [kuromoji](https://github.com/atilika/kuromoji) Kuromoji is a self-contained and very easy to use Japanese morphological analyzer designed for search
-* [kuromoji-server](https://github.com/atilika/kuromoji-server) Kuromoji server and demo that shows Japanese morphological analyzer capabilities
+* [kuromoji ![GitHub stars](https://img.shields.io/github/stars/atilika/kuromoji.svg)](https://github.com/atilika/kuromoji)  Kuromoji is a self-contained and very easy to use Japanese morphological analyzer designed for search
+* [kuromoji-server ![GitHub stars](https://img.shields.io/github/stars/atilika/kuromoji-server.svg)](https://github.com/atilika/kuromoji-server)  Kuromoji server and demo that shows Japanese morphological analyzer capabilities
 
 ###Kinyarwanda
 
 _kin :: Ikinyarwanda_
 
-* [kin-morph-fst](https://github.com/ldmt-muri/kin-morph-fst) Kinyarwanda morphological analyzer
+* [kin-morph-fst ![GitHub stars](https://img.shields.io/github/stars/ldmt-muri/kin-morph-fst.svg)](https://github.com/ldmt-muri/kin-morph-fst)  Kinyarwanda morphological analyzer
 * [TurboTagger & TurboParser for Kinyarwanda (download)](http://www.ark.cs.cmu.edu/TurboParser/nasmith_models/kin-turbo-v1.0.tgz) TurboTagger & TurboParser for Kinyarwanda
 
 ###Korean
 
 _kor :: 한국어_
 
-* [komoran](https://github.com/shineware/komoran-2.0) Korean morphological analyzer
+* [komoran ![GitHub stars](https://img.shields.io/github/stars/shineware/komoran-2.0.svg)](https://github.com/shineware/komoran-2.0)  Korean morphological analyzer
 
 ###Lingala
 
@@ -437,7 +437,7 @@ _lin :: Lingála_
 
 ###Malay
 
-* [MorfoMalayu](https://github.com/LowResourceLanguages/hltdi-morphology) morphological analysis of Malay words
+* [MorfoMalayu ![GitHub stars](https://img.shields.io/github/stars/LowResourceLanguages/hltdi-morphology.svg)](https://github.com/LowResourceLanguages/hltdi-morphology)  morphological analysis of Malay words
 
 ###Malagasy
 
@@ -449,31 +449,31 @@ _mlg :: Malagasy_
 
 _mic :: Mi'kmaq_
 
-* [migmaqLessons](https://github.com/OpenSourceFieldlinguistics/migmaqLessons)
+* [migmaqLessons ![GitHub stars](https://img.shields.io/github/stars/OpenSourceFieldlinguistics/migmaqLessons.svg)](https://github.com/OpenSourceFieldlinguistics/migmaqLessons) 
 
 ###Minderico
 
-* [fredericajordarzambarino](https://github.com/cidles/fredericajordarzambarino) A web based game for mobile devices in minderico based in the "Who Wants to be a Millionaire" TV show.
-* [mindericobot](https://github.com/cidles/mindericobot)
+* [fredericajordarzambarino ![GitHub stars](https://img.shields.io/github/stars/cidles/fredericajordarzambarino.svg)](https://github.com/cidles/fredericajordarzambarino)  A web based game for mobile devices in minderico based in the "Who Wants to be a Millionaire" TV show.
+* [mindericobot ![GitHub stars](https://img.shields.io/github/stars/cidles/mindericobot.svg)](https://github.com/cidles/mindericobot) 
 
 ###Nishnaabe
 
 _oji :: Ojibwe, Oddawa, Chippewa, Anishinaabemowin, ᐊᓂᔑᓈᐯᒧᐎᓐ
 
-* [nishanimate](https://github.com/jpmontano/nishanimate) A desktop app to facilitate Nishnaabe-language acquisition via animations produced by the natural language processing of audio-accompanied text.
+* [nishanimate ![GitHub stars](https://img.shields.io/github/stars/jpmontano/nishanimate.svg)](https://github.com/jpmontano/nishanimate)  A desktop app to facilitate Nishnaabe-language acquisition via animations produced by the natural language processing of audio-accompanied text.
 
 ###Oromo
 
 _orm :: Oromo_
 
-* [hornmorpho](https://github.com/LowResourceLanguages/hltdi-morphology) morphological analysis and generation of amharic and oromo verbs and nouns
+* [hornmorpho ![GitHub stars](https://img.shields.io/github/stars/LowResourceLanguages/hltdi-morphology.svg)](https://github.com/LowResourceLanguages/hltdi-morphology)  morphological analysis and generation of amharic and oromo verbs and nouns
 and tigrinya verbs
 
 ###Quechua
 
 _que :: Runa Simi_
 
-* [AntiMorfo](https://github.com/LowResourceLanguages/hltdi-morphology) - morphological analysis and generation of Quechua nouns, adjectives, and verbs and Spanish verbs
+* [AntiMorfo ![GitHub stars](https://img.shields.io/github/stars/LowResourceLanguages/hltdi-morphology.svg)](https://github.com/LowResourceLanguages/hltdi-morphology)  - morphological analysis and generation of Quechua nouns, adjectives, and verbs and Spanish verbs
 * [Morphology, spellchecker](http://kitt.ifi.uzh.ch/kitt/squoia/quechua.html) - XFST and FOMA, plus OpenOffice plugin.
 
 ###Sami
@@ -496,24 +496,24 @@ Giellatekno does a lot for other minority Uralic languages. Following are some k
 
 _gla :: Gàidhlig_
 
-* [hunspell-gd](https://github.com/kscanne/hunspell-gd) Files for building Scottish Gaelic spell checkers
+* [hunspell-gd ![GitHub stars](https://img.shields.io/github/stars/kscanne/hunspell-gd.svg)](https://github.com/kscanne/hunspell-gd)  Files for building Scottish Gaelic spell checkers
 
 ###Secwepemctsín
 
-* [secwepemctsnem](https://github.com/neskie/secwepemctsnem) A project to help people learn Secwepemctsín.
+* [secwepemctsnem ![GitHub stars](https://img.shields.io/github/stars/neskie/secwepemctsnem.svg)](https://github.com/neskie/secwepemctsnem)  A project to help people learn Secwepemctsín.
 
 ###Somali
 
 _som :: Soomaaliga_
 
-* [somorph](https://github.com/rtxanson/somorph) Somali morphological and syntactic analyzers and generators built on XFST and VISL-CG Constraint Grammar. Up to date version checked in in [Giellatekno's](http://giellatekno.uit.no/doc/lang/som/SomaliDocumentation.html) repository.
+* [somorph ![GitHub stars](https://img.shields.io/github/stars/rtxanson/somorph.svg)](https://github.com/rtxanson/somorph)  Somali morphological and syntactic analyzers and generators built on XFST and VISL-CG Constraint Grammar. Up to date version checked in in [Giellatekno's](http://giellatekno.uit.no/doc/lang/som/SomaliDocumentation.html) repository.
 * [qaamuus.so](http://qaamuus.so/) morphologically aware dictionary based on lexical resources found online, and the somali morphology.
 
 ###Tigrinya
 
 _tir :: ትግርኛ_
 
-* [HornMorpho](https://github.com/LowResourceLanguages/hltdi-morphology) morphological analysis and generation of Amharic and Oromo verbs and nouns and Tigrinya verbs
+* [HornMorpho ![GitHub stars](https://img.shields.io/github/stars/LowResourceLanguages/hltdi-morphology.svg)](https://github.com/LowResourceLanguages/hltdi-morphology)  morphological analysis and generation of Amharic and Oromo verbs and nouns and Tigrinya verbs
 
 ###Zulu
 


### PR DESCRIPTION
added stars for projects which are on github 
 * encourages visitors to "vote" for the projects they know and like by clicking on the starts button, and also meet other stargazers with similar interests
 * promotes projects which are more active 

0 stars is normal as we can see, and doesnt really mean anything. It could be a dormant project, a new project, or something that is just rare. 

Projects with a lot of stars are usually not LRL projects, but NLP projects used by regular developers. Having the star badge makes it easy to see these projects are clearly different from LRL but they are often useful too.

If you are looking for a type of technology you will probably look at all projects in that category (ie android apps) but the stars can give you a quick guess of which projects who might welcome you

Having stars on the list also encourages devs to get more stars on their own project, which is good for them.


Just looking at the page with stars shows how many projects are on github which might mean they have a chance at getting collaborators which is cool!

<img width="955" alt="screen shot 2015-08-02 at 1 00 01 pm" src="https://cloud.githubusercontent.com/assets/196199/9027132/9eb3fdce-3916-11e5-873c-7da7f23f0d84.png">
